### PR TITLE
add encode utf-8

### DIFF
--- a/vaila/cutvideo.py
+++ b/vaila/cutvideo.py
@@ -52,7 +52,7 @@ def save_cuts_to_txt(video_path, cuts):
     video_name = Path(video_path).stem
     txt_path = Path(video_path).parent / f"{video_name}_cuts.txt"
 
-    with open(txt_path, "w") as f:
+    with open(txt_path, "w", encoding="utf-8") as f:
         f.write(f"Cuts for video: {video_name}\n")
         f.write(f"Created: {datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n")
         f.write("-" * 50 + "\n")
@@ -69,7 +69,7 @@ def load_cuts_from_txt(video_path):
 
     cuts = []
     if txt_path.exists():
-        with open(txt_path, "r") as f:
+        with open(txt_path, "r", encoding="utf-8") as f:
             lines = f.readlines()[3:]  # Skip header lines
             for line in lines:
                 if line.strip():


### PR DESCRIPTION
Adicionei o parâmetro *encoding="utf-8"* na função open() dentro dos métodos *save_cuts_to_txt* e *load_cuts_from_txt*  porque, quando os nomes dos vídeos continham certos caracteres especiais como (*:*), que não são permitidos pela codificação padrão do Windows, ocorria o seguinte erro: *error in cutvideo 'charmap' codec can't encode character '\uff1a' in position 22: character maps to <undefined>*

Tive que definir de forma explicita o uso da codificação UTF-8 para resolver o erro.

exemplo do nome de vídeo  que contém o *:* nesse link: https://youtu.be/4GySvSySEy4