### PR TITLE
update language messabox

### DIFF
--- a/vaila/treadmill_lc.py
+++ b/vaila/treadmill_lc.py
@@ -407,7 +407,7 @@ def clean_signal_with_clicks(file_path, parent=None):
             plt.tight_layout()
             plt.show(block=False)
 
-            if not messagebox.askyesno(
+            if not ask_yes_no_english(
                 "Artifact Adjustment + Interpolation",
                 "Do you want to mark bad segments and choose an interpolation method?",
                 parent=parent,
@@ -584,7 +584,7 @@ def clean_signal_with_clicks(file_path, parent=None):
             plt.tight_layout()
             plt.show()
 
-            approved = messagebox.askyesno(
+            approved = ask_yes_no_english(
                 "Approve Adjustment + Interpolation",
                 "Do you approve this adjusted and interpolated signal?\n\n"
                 "Yes = save this final signal and TOML/JSON/CSV metadata.\n"
@@ -617,6 +617,70 @@ def clean_signal_with_clicks(file_path, parent=None):
     finally:
         plt.close("all")
         gc.collect()
+
+
+def ask_yes_no_english(title, message, parent=None) -> bool:
+    """A custom Yes/No dialog window to force English 'Yes' and 'No' buttons."""
+    # Find active root/parent window
+    dialog_parent = parent or tk._default_root or tk.Tk()
+
+    result = [False]  # Store result
+
+    dialog = tk.Toplevel(dialog_parent)
+    dialog.title(title)
+    dialog.transient(dialog_parent)
+    dialog.grab_set()
+
+    # Configure spacing and padding
+    frame = ttk.Frame(dialog, padding=20)
+    frame.pack(fill=tk.BOTH, expand=True)
+
+    # Message
+    lbl_msg = ttk.Label(frame, text=message, justify=tk.LEFT, wraplength=450)
+    lbl_msg.pack(pady=(0, 20), fill=tk.BOTH, expand=True)
+
+    # Button Frame
+    btn_frame = ttk.Frame(frame)
+    btn_frame.pack(anchor=tk.E)
+
+    def on_yes():
+        result[0] = True
+        dialog.destroy()
+
+    def on_no():
+        result[0] = False
+        dialog.destroy()
+
+    btn_yes = ttk.Button(btn_frame, text="Yes", command=on_yes, width=10)
+    btn_yes.pack(side=tk.LEFT, padx=5)
+
+    btn_no = ttk.Button(btn_frame, text="No", command=on_no, width=10)
+    btn_no.pack(side=tk.LEFT, padx=5)
+
+    # Center dialog on parent
+    dialog.update_idletasks()
+    dialog_width = dialog.winfo_width()
+    dialog_height = dialog.winfo_height()
+
+    parent_x = dialog_parent.winfo_rootx()
+    parent_y = dialog_parent.winfo_rooty()
+    parent_width = dialog_parent.winfo_width()
+    parent_height = dialog_parent.winfo_height()
+
+    try:
+        px = parent_x + (parent_width - dialog_width) // 2
+        py = parent_y + (parent_height - dialog_height) // 2
+        dialog.geometry(f"+{px}+{py}")
+    except Exception:
+        pass
+
+    # Set focus and key binds
+    btn_yes.focus_set()
+    dialog.bind("<Return>", lambda e: on_yes())
+    dialog.bind("<Escape>", lambda e: on_no())
+
+    dialog.wait_window()
+    return result[0]
 
 
 def get_output_base_folder(folder):
@@ -1655,7 +1719,7 @@ def preprocess_file_interp(file_path, config, fs=1000, root=None):
         plt.show()
         plt.close(fig)
 
-        save = messagebox.askyesno("Save", "Save final interpolated signal?", parent=root)
+        save = ask_yes_no_english("Save", "Save final interpolated signal?", parent=root)
         if save:
             res = np.column_stack((t, filtered))
             return res, filtered, t, True
@@ -2212,7 +2276,7 @@ def preprocess_file_filt(file_path, config, fs=1000, root=None, preview=True, co
             plt.close(fig)
 
             message = confirm_message or "Save final processed signal?"
-            save = messagebox.askyesno("Batch Filter Approval", message, parent=root)
+            save = ask_yes_no_english("Batch Filter Approval", message, parent=root)
             if not save:
                 return None, filtered, t
 


### PR DESCRIPTION
## Description

This Pull Request refactors the treadmill load-cell processing workflow (`treadmill_lc.py`) to simplify output directories, translate stage names to English, adjust COP plot bounds, optimize output figure organization, and enforce English Yes/No dialogs.

These changes resolve issues related to excessively long file paths on Windows (due to deeply nested subfolders), ensure the module adheres to the repository's English naming standards, and replace localized operating system prompt buttons ("Sim" / "Não") with custom English dialogs.

---

## Type of Change

- [x] **Refactoring** (non-breaking change which improves code structure/cleanliness)
- [x] **Enhancement** (improving existing features/plots and GUI consistency)
- [x] **Documentation Update** (updating help guides and README)

---

## Detailed Changes

### 1. Stage Directory Simplification & Translation

- **Directory Flattening:** Output directories for each pipeline stage (`clean`, `filtered`, `adjusted`, `results`, `figures`) are now created at the first level under the subject-day directory (`dxx`, e.g., `/s01/d02/`) instead of being deeply nested within one another.

- **English Terminology:** Translated stage names and suffixes:

  - `LIMPOS_...` → `clean_...`
  - `filtrado_...` → `filtered_...`
  - `ajustado_...` → `adjusted_...`
  - Output file suffix: `_LIMPO.csv` → `_clean.csv` *(legacy `_LIMPO` files remain fully supported for backward compatibility).*

### 2. COP (Center of Pressure) Bounds Adjustment

- Enlarged plot limits for better data trajectory visualization:

  - **Medio-Lateral (X-axis):** Set to exactly **[-50.0, 50.0] cm** (previously ±30 cm).
  - **Anterior-Posterior (Y-axis):** Set to exactly **[-100.0, 100.0] cm** (previously ±60 cm).

- Applied these limits to both Matplotlib figures and interactive Plotly HTML reports.

### 3. Figure Output Refactoring

- **Removed Trial Subfolders:** Figures are now saved directly under `figures_...` (no subfolders are created per trial).

- **Trial-Specific Filenames:** Output filenames are prefixed with the subject/day/trial identifier to prevent filename collisions:

  - `{subject}_{day}_{trial}_processing_overview.png`
  - `{subject}_{day}_{trial}_processing_strike_attributes.png`
  - `{subject}_{day}_{trial}_processing_stride_map.png`
  - `{subject}_{day}_{trial}_processing_cop_trajectory.png`
  - `{subject}_{day}_{trial}_processing_cop_report_interactive.html`

### 4. Custom English Yes/No Dialogs

- Added an `ask_yes_no_english` modal `Toplevel` dialog that always displays **English "Yes"** and **"No"** buttons, regardless of the operating system language.

- Replaced the standard `messagebox.askyesno`, which inherits localized button labels (e.g., Portuguese **"Sim"** / **"Não"**).

- Added keyboard shortcuts:
  - `Return` → **Yes**
  - `Escape` → **No**

- Configured automatic centering relative to the parent window for a more consistent user experience.

### 5. Code Quality & Version Updates

- Updated application and documentation metadata version dates to **02 July 2026** across:
  - `vaila.py`
  - `README.md`
  - `vaila/help/index.md`
  - `vaila/help/index.html`
  - `vaila/help/treadmill_lc.md`
  - `vaila/help/treadmill_lc.html`

- Removed unused variables (`axis_margin_cm`, `margin_cm`) from `treadmill_lc.py`.

---

## Verification & Testing

- **Linting:** Verified that all changes pass `uv run ruff check` without errors or warnings.

- **Unit Tests:** Updated assertions in `tests/test_treadmill_lc.py` to match the new flat directory structure and `_clean.csv` naming. All **34 treadmill unit tests** passed successfully.

- **Full Test Suite:** Executed all **429 repository tests**, with the entire suite passing successfully.

---

## 📂 Modified Files

- `vaila/treadmill_lc.py`
- `vaila.py`
- `tests/test_treadmill_lc.py`
- `README.md`
- `vaila/help/index.md`
- `vaila/help/index.html`
- `vaila/help/treadmill_lc.md`
- `vaila/help/treadmill_lc.html`