### PR TITLE
update process order

### DIFF
--- a/vaila/help/treadmill_lc.html
+++ b/vaila/help/treadmill_lc.html
@@ -21,7 +21,7 @@
 <main>
     <h1>Treadmill LC - Treadmill GRF</h1>
     <p>The <strong>Treadmill LC</strong> tool processes instrumented treadmill load-cell data in a guided workflow for running analysis. It supports artifact adjustment with interpolation review, signal filtering, calibration, body-weight normalization, center of pressure (COP), step detection, per-step metrics, and subject-day summaries.</p>
-    <p>Use it from <strong>Multimodal Analysis -&gt; Treadmill LC</strong>. The full workflow is <strong>Adjust + Interpolate -&gt; Filter -&gt; Process Metrics</strong>. The tool is TOML-configurable so the same settings can be reused for batch processing.</p>
+    <p>Use it from <strong>Multimodal Analysis -&gt; Treadmill LC</strong>. The full workflow is <strong>Filter -&gt; Adjust + Interpolate -&gt; Process Metrics</strong>. The tool is TOML-configurable so the same settings can be reused for batch processing.</p>
 
     <h2>Expected Files</h2>
     <p>The input folder can contain trial files, calibration files, and Borg metadata files. The tool separates these automatically by filename.</p>
@@ -36,7 +36,17 @@
 
     <h2>Processing Stages</h2>
 
-    <h3>1. Adjust + Interpolate</h3>
+    <h3>1. Filter</h3>
+    <ul>
+        <li>Default filter: low-pass Butterworth SOS at 40 Hz.</li>
+        <li>Median filtering uses <code>scipy.ndimage.median_filter</code> with configurable edge mode; default is <code>nearest</code>.</li>
+        <li>Zero-phase filtering uses <code>sosfiltfilt</code>.</li>
+        <li>Optional mains-noise notch filtering supports 50 Hz and 60 Hz power grids.</li>
+        <li>Available <code>filter_type</code> values: <code>lowpass</code>, <code>bandpass</code>, <code>highpass</code>, <code>median</code>, and <code>none</code>.</li>
+    </ul>
+    <p>During batch filtering, the GUI previews one calibration file and one running file. After approval, the same filter settings are applied to the remaining files without opening a plot for every file. Filtered running CSV files are saved inside <code>filtered_YYYYMMDD_HHMMSS</code> with the canonical <code>sXX_dYY_tZZ.csv</code> name, even if the input folder contains a legacy <code>*_LIMPO.csv</code> or <code>*_clean.csv</code> file. Calibration files keep their calibration names. Frequency diagnostics are saved to <code>filter_analysis_YYYYMMDD_HHMMSS</code> with explicit <code>filter_</code> names, such as <code>s01_d01_t01_filter_spectrum_metrics.csv</code> and <code>s01_d01_t01_filter_Cell_1_spectrum.png</code>.</p>
+
+    <h3>2. Adjust + Interpolate</h3>
     <ul>
         <li>Plot the four load cells and the summed signal.</li>
         <li>Select the affected load cell channels in a single multi-selection dialog, then mark intervals only on the selected cell plots.</li>
@@ -48,16 +58,6 @@
         <li>Approve the preview before saving. If rejected, the same file is reopened for correction.</li>
     </ul>
     <p>A timestamped <code>clean_YYYYMMDD_HHMMSS</code> folder is created for each adjustment run so previous runs are not overwritten. Every running trial is written there with its original name (<code>sXX_dYY_tZZ.csv</code>): adjusted/interpolated trials contain the corrected signal, and trials without marked intervals are copied unchanged. Adjustment and interpolation metadata are saved beside the CSV as <code>*_adjust_intervals.json</code>, <code>*_adjust_intervals.toml</code>, and <code>*_adjust_intervals.csv</code>.</p>
-
-    <h3>2. Filter</h3>
-    <ul>
-        <li>Default filter: low-pass Butterworth SOS at 40 Hz.</li>
-        <li>Median filtering uses <code>scipy.ndimage.median_filter</code> with configurable edge mode; default is <code>nearest</code>.</li>
-        <li>Zero-phase filtering uses <code>sosfiltfilt</code>.</li>
-        <li>Optional mains-noise notch filtering supports 50 Hz and 60 Hz power grids.</li>
-        <li>Available <code>filter_type</code> values: <code>lowpass</code>, <code>bandpass</code>, <code>highpass</code>, <code>median</code>, and <code>none</code>.</li>
-    </ul>
-    <p>During batch filtering, the GUI previews one calibration file and one running file. After approval, the same filter settings are applied to the remaining files without opening a plot for every file. Filtered running CSV files are saved inside <code>filtered_YYYYMMDD_HHMMSS</code> with the canonical <code>sXX_dYY_tZZ.csv</code> name, even if the input folder contains a legacy <code>*_LIMPO.csv</code> or <code>*_clean.csv</code> file. Calibration files keep their calibration names. Frequency diagnostics are saved to <code>filter_analysis_YYYYMMDD_HHMMSS</code> with explicit <code>filter_</code> names, such as <code>s01_d01_t01_filter_spectrum_metrics.csv</code> and <code>s01_d01_t01_filter_Cell_1_spectrum.png</code>.</p>
 
     <h3>3. Process Metrics</h3>
     <ul>
@@ -102,9 +102,9 @@
 
     <h2>GUI Usage</h2>
     <ul>
-        <li><strong>Run Full Pipeline</strong>: Adjust + Interpolate -&gt; Filter -&gt; Process Metrics.</li>
-        <li><strong>Adjust + Interpolate</strong>: Only artifact correction and interpolation review.</li>
+        <li><strong>Run Full Pipeline</strong>: Filter -&gt; Adjust + Interpolate -&gt; Process Metrics.</li>
         <li><strong>Filter Only</strong>: Only filtering and frequency diagnostics.</li>
+        <li><strong>Adjust + Interpolate</strong>: Only artifact correction and interpolation review.</li>
         <li><strong>Process Metrics Only</strong>: Only calibration and running metrics.</li>
         <li><strong>Create TOML Template</strong>: Save a reusable configuration file.</li>
         <li><strong>Help</strong>: Open this documentation.</li>
@@ -115,7 +115,7 @@
     <p>Common <code>--step</code> values are <code>all</code>, <code>adjust</code>, <code>filter</code>, and <code>process</code>.</p>
 
     <div class="footer">
-        <p>Version: 0.3.68 | Updated: 02 July 2026</p>
+        <p>Version: 0.3.80 | Updated: 08 July 2026</p>
     </div>
 </main>
 </body>

--- a/vaila/help/treadmill_lc.md
+++ b/vaila/help/treadmill_lc.md
@@ -6,8 +6,8 @@ The **Treadmill LC** tool processes instrumented treadmill load-cell data in a g
 
 Use it from **Multimodal Analysis -> Treadmill LC**. The full workflow is:
 
-1. **Adjust + Interpolate**
-2. **Filter**
+1. **Filter**
+2. **Adjust + Interpolate**
 3. **Process Metrics**
 
 The tool is TOML-configurable so the same settings can be reused for batch processing.
@@ -26,9 +26,23 @@ Borg TXT files are not processed as trials. When a matching Borg file has a `Pes
 
 ## Processing Stages
 
-### 1. Adjust + Interpolate
+### 1. Filter
 
-This stage is used to correct artifacts before filtering and metric extraction.
+This stage smooths the signal while preserving treadmill force behavior.
+
+- Default filter: low-pass Butterworth SOS at 40 Hz.
+- Median filtering uses `scipy.ndimage.median_filter` with configurable edge mode; default is `nearest`.
+- Zero-phase filtering uses `sosfiltfilt`.
+- Optional mains-noise notch filtering supports 50 Hz and 60 Hz power grids.
+- Available `filter_type` values: `lowpass`, `bandpass`, `highpass`, `median`, and `none`.
+
+During batch filtering, the GUI previews one calibration file and one running file. After approval, the same filter settings are applied to the remaining files without opening a plot for every file.
+
+Filtered running CSV files are saved inside `filtered_YYYYMMDD_HHMMSS` with the canonical `sXX_dYY_tZZ.csv` name, even if the input folder contains a legacy `*_LIMPO.csv` or `*_clean.csv` file. Calibration files keep their calibration names. Frequency diagnostics are saved to `filter_analysis_YYYYMMDD_HHMMSS` with explicit `filter_` names, such as `s01_d01_t01_filter_spectrum_metrics.csv` and `s01_d01_t01_filter_Cell_1_spectrum.png`.
+
+### 2. Adjust + Interpolate
+
+This stage is used to correct artifacts after filtering and before metric extraction.
 
 - Plot the four load cells and the summed signal.
 - Select the affected load cell channels in a single multi-selection dialog, then mark intervals only on the selected cell plots.
@@ -46,20 +60,6 @@ A timestamped `clean_YYYYMMDD_HHMMSS` folder is created for each adjustment run 
 - `*_adjust_intervals.csv`
 
 The metadata records intervals, selected cells, interval treatment, selected interpolation methods, final method, and interpolation parameters.
-
-### 2. Filter
-
-This stage smooths the signal while preserving treadmill force behavior.
-
-- Default filter: low-pass Butterworth SOS at 40 Hz.
-- Median filtering uses `scipy.ndimage.median_filter` with configurable edge mode; default is `nearest`.
-- Zero-phase filtering uses `sosfiltfilt`.
-- Optional mains-noise notch filtering supports 50 Hz and 60 Hz power grids.
-- Available `filter_type` values: `lowpass`, `bandpass`, `highpass`, `median`, and `none`.
-
-During batch filtering, the GUI previews one calibration file and one running file. After approval, the same filter settings are applied to the remaining files without opening a plot for every file.
-
-Filtered running CSV files are saved inside `filtered_YYYYMMDD_HHMMSS` with the canonical `sXX_dYY_tZZ.csv` name, even if the input folder contains a legacy `*_LIMPO.csv` or `*_clean.csv` file. Calibration files keep their calibration names. Frequency diagnostics are saved to `filter_analysis_YYYYMMDD_HHMMSS` with explicit `filter_` names, such as `s01_d01_t01_filter_spectrum_metrics.csv` and `s01_d01_t01_filter_Cell_1_spectrum.png`.
 
 ### 3. Process Metrics
 
@@ -138,9 +138,9 @@ For batch processing, create a TOML once, review it in the GUI editor, then reus
 
 Open **Multimodal Analysis -> Treadmill LC** and choose:
 
-- **Run Full Pipeline**: Adjust + Interpolate -> Filter -> Process Metrics.
-- **Adjust + Interpolate**: Only artifact correction and interpolation review.
+- **Run Full Pipeline**: Filter -> Adjust + Interpolate -> Process Metrics.
 - **Filter Only**: Only filtering and frequency diagnostics.
+- **Adjust + Interpolate**: Only artifact correction and interpolation review.
 - **Process Metrics Only**: Only calibration and running metrics.
 - **Create TOML Template**: Save a reusable configuration file.
 - **Help**: Open this documentation.
@@ -156,5 +156,5 @@ uv run python -m vaila.treadmill_lc --input-dir /path/to/csv_folder --step all
 Common `--step` values are `all`, `adjust`, `filter`, and `process`.
 
 ---
-- **Version**: 0.3.68
-- **Updated**: 02 July 2026
+- **Version**: 0.3.80
+- **Updated**: 08 July 2026

--- a/vaila/treadmill_lc.py
+++ b/vaila/treadmill_lc.py
@@ -9,8 +9,8 @@ Author: Abel Gonçalves Chinaglia
 Email: abel.chinaglia@usp.br
 GitHub: https://github.com/vaila-multimodaltoolbox/vaila
 Creation Date: 09 June 2026
-Update Date: 02 July 2026
-Version: 0.3.68
+Update Date: 08 July 2026
+Version: 0.3.80
 
 Description:
 ------------
@@ -619,68 +619,46 @@ def clean_signal_with_clicks(file_path, parent=None):
         gc.collect()
 
 
+class YesNoDialog(simpledialog.Dialog):
+    """Custom Yes/No dialog window that inherits from simpledialog.Dialog to match project aesthetics."""
+    def __init__(self, parent, title, message):
+        self.message = message
+        self.result = False
+        super().__init__(parent, title=title)
+
+    def body(self, master):
+        lbl = ttk.Label(master, text=self.message, justify="left", wraplength=400)
+        lbl.pack(padx=20, pady=15, fill="both", expand=True)
+        return lbl
+
+    def buttonbox(self):
+        box = ttk.Frame(self)
+
+        btn_yes = ttk.Button(box, text="Yes", width=10, command=self.yes)
+        btn_yes.pack(side="left", padx=5, pady=5)
+
+        btn_no = ttk.Button(box, text="No", width=10, command=self.no)
+        btn_no.pack(side="left", padx=5, pady=5)
+
+        self.bind("<Return>", self.yes)
+        self.bind("<Escape>", self.no)
+
+        box.pack(anchor="e", padx=15, pady=(0, 10))
+
+    def yes(self, event=None):
+        self.result = True
+        self.ok()
+
+    def no(self, event=None):
+        self.result = False
+        self.cancel()
+
+
 def ask_yes_no_english(title, message, parent=None) -> bool:
-    """A custom Yes/No dialog window to force English 'Yes' and 'No' buttons."""
-    # Find active root/parent window
+    """A standard-themed Yes/No dialog window forcing English 'Yes' and 'No' buttons."""
     dialog_parent = parent or tk._default_root or tk.Tk()
-
-    result = [False]  # Store result
-
-    dialog = tk.Toplevel(dialog_parent)
-    dialog.title(title)
-    dialog.transient(dialog_parent)
-    dialog.grab_set()
-
-    # Configure spacing and padding
-    frame = ttk.Frame(dialog, padding=20)
-    frame.pack(fill=tk.BOTH, expand=True)
-
-    # Message
-    lbl_msg = ttk.Label(frame, text=message, justify=tk.LEFT, wraplength=450)
-    lbl_msg.pack(pady=(0, 20), fill=tk.BOTH, expand=True)
-
-    # Button Frame
-    btn_frame = ttk.Frame(frame)
-    btn_frame.pack(anchor=tk.E)
-
-    def on_yes():
-        result[0] = True
-        dialog.destroy()
-
-    def on_no():
-        result[0] = False
-        dialog.destroy()
-
-    btn_yes = ttk.Button(btn_frame, text="Yes", command=on_yes, width=10)
-    btn_yes.pack(side=tk.LEFT, padx=5)
-
-    btn_no = ttk.Button(btn_frame, text="No", command=on_no, width=10)
-    btn_no.pack(side=tk.LEFT, padx=5)
-
-    # Center dialog on parent
-    dialog.update_idletasks()
-    dialog_width = dialog.winfo_width()
-    dialog_height = dialog.winfo_height()
-
-    parent_x = dialog_parent.winfo_rootx()
-    parent_y = dialog_parent.winfo_rooty()
-    parent_width = dialog_parent.winfo_width()
-    parent_height = dialog_parent.winfo_height()
-
-    try:
-        px = parent_x + (parent_width - dialog_width) // 2
-        py = parent_y + (parent_height - dialog_height) // 2
-        dialog.geometry(f"+{px}+{py}")
-    except Exception:
-        pass
-
-    # Set focus and key binds
-    btn_yes.focus_set()
-    dialog.bind("<Return>", lambda e: on_yes())
-    dialog.bind("<Escape>", lambda e: on_no())
-
-    dialog.wait_window()
-    return result[0]
+    dialog = YesNoDialog(dialog_parent, title, message)
+    return dialog.result
 
 
 def get_output_base_folder(folder):
@@ -3988,7 +3966,7 @@ class LoadCellTreadmillDialog(tk.Toplevel):
 
         ttk.Label(
             frame,
-            text="Run the full sequence or launch one pipeline step. Artifact adjustment and interpolation run before filtering.",
+            text="Run the full sequence or launch one pipeline step. Signal filtering runs before artifact adjustment and interpolation.",
             wraplength=540,
             justify="center",
             foreground="#64748b",
@@ -4011,16 +3989,16 @@ class LoadCellTreadmillDialog(tk.Toplevel):
 
         ttk.Button(
             stages_frame,
-            text="1. Adjust + Interpolate",
+            text="1. Filter Only (Zero-Phase + PSD)",
             style="Secondary.TButton",
-            command=lambda: self._execute_stage("adjust"),
+            command=lambda: self._execute_stage("filter"),
         ).pack(fill="x", pady=3)
 
         ttk.Button(
             stages_frame,
-            text="2. Filter Only (Zero-Phase + PSD)",
+            text="2. Adjust + Interpolate",
             style="Secondary.TButton",
-            command=lambda: self._execute_stage("filter"),
+            command=lambda: self._execute_stage("adjust"),
         ).pack(fill="x", pady=3)
 
         ttk.Button(
@@ -4065,7 +4043,7 @@ class LoadCellTreadmillDialog(tk.Toplevel):
 
     def _run_full_pipeline(self) -> None:
         self._write_log(
-            "Starting Full Sequential Pipeline (Ajuste+Interpolação -> Filtragem -> Processamento)"
+            "Starting Full Sequential Pipeline (Filtragem -> Ajuste+Interpolação -> Processamento)"
         )
 
         # 1. Ask for raw folder
@@ -4074,25 +4052,25 @@ class LoadCellTreadmillDialog(tk.Toplevel):
             self._write_log("Pipeline canceled by user.")
             return
 
-        # 2. Stage 1: Adjust + Interpolate raw trials before filtering
-        self._write_log("Executing Stage 1: Artifact Adjustment + Interpolation...")
-        limpos_folder = run_adjust_stage(parent=self, initial_dir=raw_folder)
-        if not limpos_folder:
-            self._write_log("Pipeline stopped after Stage 1 (Adjustment+Interpolation).")
+        # 2. Stage 1: Filter raw signals
+        self._write_log("Executing Stage 1: Signal Filtering...")
+        filtrado_folder = run_filter_stage(parent=self, initial_dir=raw_folder)
+        if not filtrado_folder:
+            self._write_log("Pipeline stopped after Stage 1 (Filtering).")
             return
 
-        # 3. Stage 2: Filter adjusted/interpolated signals
-        self._write_log(f"Executing Stage 2: Signal Filtering on folder '{limpos_folder}'...")
-        filtrado_folder = run_filter_stage(parent=self, initial_dir=limpos_folder)
-        if not filtrado_folder:
-            self._write_log("Pipeline stopped after Stage 2 (Filtering).")
+        # 3. Stage 2: Adjust + Interpolate filtered signals
+        self._write_log(f"Executing Stage 2: Artifact Adjustment + Interpolation on folder '{filtrado_folder}'...")
+        limpos_folder = run_adjust_stage(parent=self, initial_dir=filtrado_folder)
+        if not limpos_folder:
+            self._write_log("Pipeline stopped after Stage 2 (Adjustment+Interpolation).")
             return
 
         # 4. Stage 3: Process Metrics
         self._write_log(
-            f"Executing Stage 3: Biomechanical Metrics on folder '{filtrado_folder}'..."
+            f"Executing Stage 3: Biomechanical Metrics on folder '{limpos_folder}'..."
         )
-        results_folder = run_process_stage(parent=self, initial_dir=filtrado_folder)
+        results_folder = run_process_stage(parent=self, initial_dir=limpos_folder)
         if not results_folder:
             self._write_log("Pipeline stopped after Stage 3 (Processing).")
             return
@@ -4153,13 +4131,13 @@ def main(argv: list[str] | None = None) -> int:
         root.withdraw()
         if args.step == "all":
             # sequential pipeline on input_dir
-            limpos = run_adjust_stage(parent=root, initial_dir=args.input_dir)
-            if limpos:
-                ajustado = run_interpolate_stage(parent=root, initial_dir=limpos)
-                if ajustado:
-                    filtrado = run_filter_stage(parent=root, initial_dir=ajustado)
-                    if filtrado:
-                        run_process_stage(parent=root, initial_dir=filtrado)
+            filtrado = run_filter_stage(parent=root, initial_dir=args.input_dir)
+            if filtrado:
+                limpos = run_adjust_stage(parent=root, initial_dir=filtrado)
+                if limpos:
+                    ajustado = run_interpolate_stage(parent=root, initial_dir=limpos)
+                    if ajustado:
+                        run_process_stage(parent=root, initial_dir=ajustado)
         elif args.step == "adjust":
             run_adjust_stage(parent=root, initial_dir=args.input_dir)
         elif args.step == "interpolate":


### PR DESCRIPTION
## Overview
This pull request modifies the instrumented treadmill load-cell processing module (`treadmill_lc.py`) to swap the sequence of pipeline stages, updates the accompanying documentation, and standardizes the Yes/No dialog to match the application's visual guidelines while keeping English button labels.

## Key Changes

### 1. Swapped Pipeline Stage Order (Filtering First)
* **Execution Flow**: Swapped Stage 1 (Artifact Adjustment + Interpolation) and Stage 2 (Signal Filtering). The workflow now correctly runs:
  $$\text{Signal Filtering} \rightarrow \text{Artifact Adjustment + Interpolation} \rightarrow \text{Biomechanical Metrics}$$
* **GUI & CLI**:
* Reorganized the layout of the **Individual Stages** side buttons so that **Filter Only** is presented first.
* Updated the sequential pipeline execution path for the `--step all` parameter in the CLI main block.
* Updated pipeline instructions and log messages to show `Filtragem -> Ajuste+Interpolação -> Processamento`.
* **Documentation**: Modified `vaila/help/treadmill_lc.md` and `vaila/help/treadmill_lc.html` to reflect the new sequence and updated the module version to `0.3.80` (Update Date: `08 July 2026`).

### 2. Standardized English Yes/No Dialog
* Introduced `YesNoDialog` inheriting from `simpledialog.Dialog` to replace a custom, non-standard `Toplevel` implementation.
* Styled the dialog utilizing `ttk.Label` and `ttk.Button` to guarantee it shares the same native OS border, spacing, typography, and theme styling as other parameters dialogs (like `FilterConfigDialog`).
* Configured buttons explicitly with **"Yes"** and **"No"** English text to override OS locale defaults (e.g., *Sim/Não* in Portuguese systems) while retaining default keyboard navigation behavior (confirming with `Enter`, cancelling/aborting with `Escape`).

## Validation & Testing
* All **34 unit/integration tests** in `tests/test_treadmill_lc.py` pass cleanly.
* A full run of the entire repository test suite (**513 tests**) passed successfully, confirming no regressions.
