### PR TITLE
fix(lfs): stop tracking .tflite as LFS in vaila/models

### DIFF
--- a/vaila/models/.gitattributes
+++ b/vaila/models/.gitattributes
@@ -28,7 +28,6 @@
 saved_model/**/* filter=lfs diff=lfs merge=lfs -text
 *.tar.* filter=lfs diff=lfs merge=lfs -text
 *.tar filter=lfs diff=lfs merge=lfs -text
-*.tflite filter=lfs diff=lfs merge=lfs -text
 *.tgz filter=lfs diff=lfs merge=lfs -text
 *.wasm filter=lfs diff=lfs merge=lfs -text
 *.xz filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
image_segmenter_selfie_landscape.tflite is committed as a real binary blob, not an LFS pointer. The inherited *.tflite LFS rule caused 'should have been a pointer, but wasn't' warnings on fresh clones. File is small (~250KB); LFS not needed.